### PR TITLE
Fix for mesh walking component

### DIFF
--- a/AssimpReader.cpp
+++ b/AssimpReader.cpp
@@ -10,7 +10,7 @@ Mesh AssimpReader::readObj(std::string fileName)
     Assimp::Importer importer;
     const aiScene* scene = importer
                 .ReadFile(fileName.c_str(),
-                          aiProcess_Triangulate|aiProcess_FixInfacingNormals);
+                          /*aiProcess_Triangulate|*/aiProcess_FixInfacingNormals);
     if(!scene){
         std::cout << "Mesh load failed!: " << fileName << std::endl;
         // TODO error dialog

--- a/CustomSchemeSubdivisionStrategy.cpp
+++ b/CustomSchemeSubdivisionStrategy.cpp
@@ -84,6 +84,8 @@ Mesh::Vertex CustomSchemeSubdivisionStrategy::calculateNewEdgeVert(Polyhedron::H
         result += Mesh::toQVector(walk.atOdds(i)) * weights[i];
     }
 
+    //std::cout << Mesh::toKernelVector(result) << std::endl;
+
     return Mesh::toVertex(result);
 }
 
@@ -116,8 +118,7 @@ Mesh::Vertex CustomSchemeSubdivisionStrategy::calculateNewFaceVert(Polyhedron::F
         result += Mesh::toQVector(walk.atOdds(i)) * weights[i];
     }
 
-    auto p = (Mesh::toKernelVector(result));
-    std::cout << p << std::endl;
+    //std::cout << Mesh::toKernelVector(result) << std::endl;
 
     return Mesh::toVertex(result);
 }
@@ -150,6 +151,8 @@ Mesh::Vertex CustomSchemeSubdivisionStrategy::calculateNewEvenVert(Polyhedron::V
     for (int i = 0; i < walk.n_evens; ++i) {
         result += Mesh::toQVector(walk.atEvens(i)) * weights[i];
     }
+
+    //std::cout << Mesh::toKernelVector(result) << std::endl;
 
     return {result, QVector3D(), QVector3D(1, 1, 1)};
 }

--- a/CustomSchemeSubdivisionStrategy.cpp
+++ b/CustomSchemeSubdivisionStrategy.cpp
@@ -1,12 +1,14 @@
 #include "CustomSchemeSubdivisionStrategy.h"
 
 Mesh CustomSchemeSubdivisionStrategy::doSubdivision(Mesh evenMesh) {
-    Polyhedron old_mesh = evenMesh.convertToSurfaceMesh();
+    bool doTriangulate = evenMesh.m_numFaceVertices == 4 && custom_scheme.mesh_type == CustomSchemeMeshType::Tri;
+    Polyhedron old_mesh = evenMesh.convertToSurfaceMesh(doTriangulate);
 
     std::map<Polyhedron::Halfedge_iterator, Mesh::Vertex> new_edge_vertices;
     std::map<Polyhedron::Facet_iterator, Mesh::Vertex> new_face_vertices;
 
     // kiszámol új edge vertices
+    std::cout << "Calculating edge vertices..." << std::endl;
     for (Polyhedron::Halfedge_iterator it = old_mesh.halfedges_begin(); it != old_mesh.halfedges_end(); ++it) {
         if (new_edge_vertices.find(it) == new_edge_vertices.end()) {
             Mesh::Vertex new_edge_vert = calculateNewEdgeVert(it);
@@ -17,6 +19,7 @@ Mesh CustomSchemeSubdivisionStrategy::doSubdivision(Mesh evenMesh) {
 
     // kiszámol új face vertices, csak ha QUAD
     if (custom_scheme.mesh_type == CustomSchemeMeshType::Quad) {
+        std::cout << "Calculating face vertices..." << std::endl;
         for (Polyhedron::Facet_iterator it = old_mesh.facets_begin(); it != old_mesh.facets_end(); ++it) {
             Mesh::Vertex new_face_vert = calculateNewFaceVert(it);
             new_face_vertices[it] = new_face_vert;
@@ -26,6 +29,7 @@ Mesh CustomSchemeSubdivisionStrategy::doSubdivision(Mesh evenMesh) {
     // frissít even vertices, csak ha APPROX
     std::map<Polyhedron::Vertex_iterator, Mesh::Vertex> new_even_vertices;
     if (custom_scheme.refinement_type == CustomSchemeRefinementType::Approx) {
+        std::cout << "Calculating even vertices..." << std::endl;
         for (Polyhedron::Vertex_iterator it = old_mesh.vertices_begin(); it != old_mesh.vertices_end(); ++it) {
             Mesh::Vertex new_even_vert = calculateNewEvenVert(it);
             new_even_vertices[it] = new_even_vert;
@@ -45,7 +49,7 @@ Mesh CustomSchemeSubdivisionStrategy::doSubdivision(Mesh evenMesh) {
         }
     }
 
-    Mesh result(vertices, face_indicies, custom_scheme.mesh_type == CustomSchemeMeshType::Tri ? 3 : 4);
+    Mesh result(vertices, face_indicies, doTriangulate ? 3 : evenMesh.m_numFaceVertices);
     result.generateIndices(false);
 
     return result;
@@ -56,15 +60,16 @@ Mesh::Vertex CustomSchemeSubdivisionStrategy::calculateNewEdgeVert(Polyhedron::H
     MeshWalkHandler::Walk walk = mwh.walk(
                 halfedge,
                 custom_scheme.neighbour_level,
-                static_cast<SubdivisionType>(custom_scheme.refinement_type),
+                custom_scheme.refinement_type == CustomSchemeRefinementType::Approx ? SubdivisionType::Approximating : SubdivisionType::Interpolating,
                 MeshWalkHandler::OddsType::Edge,
-                static_cast<MeshType>(custom_scheme.mesh_type));
+                custom_scheme.mesh_type == CustomSchemeMeshType::Tri ? MeshType::Triangular : MeshType::Quadrilateral);
 
     // generate weight array
     WeightArrayGenerator& wag = WeightArrayGenerator::getInstance();
     std::array<float, 16> weights = wag.generateWeights(custom_scheme, MeshWalkHandler::OddsType::Edge);
 
     /*
+    std::cout << "EDGE" << std::endl;
     std::cout << "Odds_num: " << walk.n_odds << std::endl;
     std::cout << "Weight array" << std::endl;
     for(float f : weights) {
@@ -87,19 +92,32 @@ Mesh::Vertex CustomSchemeSubdivisionStrategy::calculateNewFaceVert(Polyhedron::F
     MeshWalkHandler::Walk walk = mwh.walk(
                 facet->halfedge(),
                 custom_scheme.neighbour_level,
-                static_cast<SubdivisionType>(custom_scheme.refinement_type),
-                MeshWalkHandler::OddsType::Edge,
-                static_cast<MeshType>(custom_scheme.mesh_type));
+                custom_scheme.refinement_type == CustomSchemeRefinementType::Approx ? SubdivisionType::Approximating : SubdivisionType::Interpolating,
+                MeshWalkHandler::OddsType::Face,
+                MeshType::Quadrilateral);
 
     // generate weight array
     WeightArrayGenerator& wag = WeightArrayGenerator::getInstance();
     std::array<float, 16> weights = wag.generateWeights(custom_scheme, MeshWalkHandler::OddsType::Face);
+
+    /*
+    std::cout << "FACE" << std::endl;
+    std::cout << "Odds_num: " << walk.n_odds << std::endl;
+    std::cout << "Weight array" << std::endl;
+    for(float f : weights) {
+        std::cout << f << std::endl;
+    }
+    std::cout << std::endl;
+    */
 
     // do multiply
     QVector3D result;
     for (int i = 0; i < walk.n_odds; ++i) {
         result += Mesh::toQVector(walk.atOdds(i)) * weights[i];
     }
+
+    auto p = (Mesh::toKernelVector(result));
+    std::cout << p << std::endl;
 
     return Mesh::toVertex(result);
 }
@@ -111,13 +129,14 @@ Mesh::Vertex CustomSchemeSubdivisionStrategy::calculateNewEvenVert(Polyhedron::V
                 custom_scheme.neighbour_level,
                 SubdivisionType::Approximating,
                 MeshWalkHandler::OddsType::Edge,
-                static_cast<MeshType>(custom_scheme.mesh_type));
+                custom_scheme.mesh_type == CustomSchemeMeshType::Tri ? MeshType::Triangular : MeshType::Quadrilateral);
 
     // generate weight array
     WeightArrayGenerator& wag = WeightArrayGenerator::getInstance();
     std::vector<float> weights = wag.generateEvenWeights(custom_scheme, walk.n_evens - 1);
 
     /*
+    std::cout << "EVEN" << std::endl;
     std::cout << "Evens_num: " << walk.n_evens << std::endl;
     std::cout << "Weight array" << std::endl;
     for(float f : weights) {
@@ -132,7 +151,7 @@ Mesh::Vertex CustomSchemeSubdivisionStrategy::calculateNewEvenVert(Polyhedron::V
         result += Mesh::toQVector(walk.atEvens(i)) * weights[i];
     }
 
-    return Mesh::toVertex(result);
+    return {result, QVector3D(), QVector3D(1, 1, 1)};
 }
 
 void CustomSchemeSubdivisionStrategy::calculateFacesTri(QVector<Mesh::Vertex>& vertices,
@@ -252,6 +271,9 @@ void CustomSchemeSubdivisionStrategy::calculateFacesQuad(QVector<Mesh::Vertex>& 
 
     int new_face_vert_index = vertices.size();
     vertices.push_back(new_face_vertices[it]);
+
+    //std::cout << "edge_map:" << std::endl << edge_map << std::endl;
+    //std::cout << "even_map:" << std::endl << even_map << std::endl;
 
     face_indicies.push_back(new_face_indices[0]);
     face_indicies.push_back(new_face_indices[1]);

--- a/CustomSchemeWindow.cpp
+++ b/CustomSchemeWindow.cpp
@@ -128,46 +128,42 @@ CustomSchemeWindow::~CustomSchemeWindow()
 
 void CustomSchemeWindow::onTriggered_Approx()
 {
+    custom_scheme.refinement_type = CustomSchemeRefinementType::Approx;
     updateWeightsLayout();
 }
 
 void CustomSchemeWindow::onTriggered_Interp()
 {
+    custom_scheme.refinement_type = CustomSchemeRefinementType::Interp;
     updateWeightsLayout();
 }
 
 void CustomSchemeWindow::onTriggered_Tri()
 {
+    custom_scheme.mesh_type = CustomSchemeMeshType::Tri;
     updateWeightsLayout();
 }
 
 void CustomSchemeWindow::onTriggered_Quad()
 {
+    custom_scheme.mesh_type = CustomSchemeMeshType::Quad;
     updateWeightsLayout();
 }
 
 void CustomSchemeWindow::onTriggered_FirstNeighbours()
 {
+    custom_scheme.neighbour_level = 1;
     updateWeightsLayout();
 }
 
 void CustomSchemeWindow::onTriggered_SecondNeighbours()
 {
+    custom_scheme.neighbour_level = 2;
     updateWeightsLayout();
 }
 
 void CustomSchemeWindow::onTriggered_okButton()
 {
-
-    CustomSchemeRefinementType refinement_type = static_cast<CustomSchemeRefinementType>(schemeTypesGroup->checkedAction()->data().toInt());
-    CustomSchemeMeshType mesh_type = static_cast<CustomSchemeMeshType>(shapeGroup->checkedAction()->data().toInt());
-    int neighbour_level = neighbourGroup->checkedAction()->data().toInt();
-
-    CustomScheme custom_scheme;
-    custom_scheme.refinement_type = refinement_type;
-    custom_scheme.mesh_type = mesh_type;
-    custom_scheme.neighbour_level = neighbour_level;
-
     custom_scheme.name = leSchemeName->text().toStdString();
 
     QLocale locale;
@@ -209,6 +205,7 @@ void CustomSchemeWindow::onTriggered_okButton()
 
     custom_scheme.weights = Weights{odds, even};
 
+    std::cout << "Created custom scheme: " << std::endl << custom_scheme << std::endl;
     CustomSchemeHandler& csh = CustomSchemeHandler::getInstance();
     csh.setCurrentCustomScheme(custom_scheme);
 
@@ -428,22 +425,22 @@ void CustomSchemeWindow::createActions()
 {
     approxAction = new QAction(tr("Approximating"), this);
     approxAction->setCheckable(true);
-    approxAction->setData(CustomSchemeRefinementType::Approx);
+    approxAction->setData(0);
     connect(approxAction, &QAction::triggered, this, &CustomSchemeWindow::onTriggered_Approx);
 
     interpolAction = new QAction(tr("Interpolating"), this);
     interpolAction->setCheckable(true);
-    interpolAction->setData(CustomSchemeRefinementType::Interp);
+    interpolAction->setData(1);
     connect(interpolAction, &QAction::triggered, this, &CustomSchemeWindow::onTriggered_Interp);
 
     triAction = new QAction(tr("Triangle Mesh"), this);
     triAction->setCheckable(true);
-    triAction->setData(CustomSchemeMeshType::Tri);
+    triAction->setData(0);
     connect(triAction, &QAction::triggered, this, &CustomSchemeWindow::onTriggered_Tri);
 
     quadAction = new QAction(tr("Quad Mesh"), this);
     quadAction->setCheckable(true);
-    quadAction->setData(CustomSchemeMeshType::Quad);
+    quadAction->setData(1);
     connect(quadAction, &QAction::triggered, this, &CustomSchemeWindow::onTriggered_Quad);
 
     firstNeighbourAction = new QAction(tr("First Neighbours"), this);
@@ -460,14 +457,18 @@ void CustomSchemeWindow::createActions()
     schemeTypesGroup->addAction(approxAction);
     schemeTypesGroup->addAction(interpolAction);
     approxAction->setChecked(true);
+    custom_scheme.refinement_type = CustomSchemeRefinementType::Approx;
 
     shapeGroup = new QActionGroup(this);
     shapeGroup->addAction(triAction);
     shapeGroup->addAction(quadAction);
     triAction->setChecked(true);
+    custom_scheme.mesh_type = CustomSchemeMeshType::Tri;
 
     neighbourGroup = new QActionGroup(this);
     neighbourGroup->addAction(firstNeighbourAction);
     neighbourGroup->addAction(secondNeighbourAction);
     firstNeighbourAction->setChecked(true);
+    custom_scheme.neighbour_level = 1;
+
 }

--- a/CustomSchemeWindow.cpp
+++ b/CustomSchemeWindow.cpp
@@ -106,7 +106,6 @@ CustomSchemeWindow::CustomSchemeWindow(QWidget *parent) :
     sidebarVBox->addWidget(groupBoxShapes);
     sidebarVBox->addWidget(groupBoxNeighbours);
 
-    std::cout<<"WTF"<<std::endl;
     updateWeightsLayout();
 
     sidebarVBox->addLayout(vBoxWeights);

--- a/CustomSchemeWindow.h
+++ b/CustomSchemeWindow.h
@@ -99,6 +99,8 @@ private:
 
     QPushButton* okButton;
     QPushButton* cancelButton;
+
+    CustomScheme custom_scheme;
 };
 
 #endif // CUSTOMSCHEMEWINDOW_H

--- a/DebugHelper.cpp
+++ b/DebugHelper.cpp
@@ -39,14 +39,26 @@ std::ostream& operator<<(std::ostream& os, const QVector<Mesh::Vertex>& vertices
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const Polyhedron::Halfedge_iterator& he) {
+    os << "[" << he->opposite()->vertex() << " -> " << he->vertex() << "]";
+
+    return os;
+}
+
 std::ostream& operator<<(std::ostream& os, const std::map<Polyhedron::Halfedge_iterator, int>& edge_map) {
     // write obj to stream
     os << "[" << std::endl;
 
     for (auto p : edge_map) {
-        os << "(" << &(p.first) << ", " << p.second<< ")" << std::endl;
+        os << "(" << p.first << ", " << p.second<< ")" << std::endl;
     }
     os << "]" << std::endl;
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const Polyhedron::Vertex_iterator& v) {
+    Polyhedron::Point_3 p = v->point();
+    os << "(" << p.x() << ", " << p.y() << ", " << p.z()<< ")";
     return os;
 }
 
@@ -55,7 +67,7 @@ std::ostream& operator<<(std::ostream& os, const std::map<Polyhedron::Vertex_ite
     os << "[" << std::endl;
 
     for (auto p : even_map) {
-        os << "(" << &(p.first) << ", " << p.second<< ")" << std::endl;
+        os << "[" << (p.first) << ", " << p.second<< "]" << std::endl;
     }
     os << "]" << std::endl;
     return os;

--- a/DebugHelper.h
+++ b/DebugHelper.h
@@ -8,7 +8,9 @@
 std::ostream& operator<<(std::ostream& os, const Mesh::Vertex& vertex);
 std::ostream& operator<<(std::ostream& os, const QVector<int>& indices);
 std::ostream& operator<<(std::ostream& os, const QVector<Mesh::Vertex>& vertices);
+std::ostream& operator<<(std::ostream& os, const Polyhedron::Halfedge_iterator& he);
 std::ostream& operator<<(std::ostream& os, const std::map<Polyhedron::Halfedge_iterator, int>& edge_map);
+std::ostream& operator<<(std::ostream& os, const Polyhedron::Vertex_iterator&  v);
 std::ostream& operator<<(std::ostream& os, const std::map<Polyhedron::Vertex_iterator, int>& even_map);
 
 #endif // DEBUGHELPER_H

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -119,6 +119,8 @@ void MainWindow::onTriggered_CustomSchemeSubdiv()
 
     SubdivisionController& sc = SubdivisionController::getInstance();
     sc.switchTo(SubdivisionScheme::Custom);
+
+    openglWidget->update();
 }
 
 void MainWindow::onTriggered_CreateCustomScheme()

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -24,7 +24,9 @@ MainWindow::MainWindow(QWidget *parent) :
     label->setAlignment(Qt::AlignCenter);
 
     subdivisionButton = new QPushButton("Subdivision");
+    subdivisionButton->setFixedWidth(subdivControlsWidth/2-10);
     revertButton = new QPushButton("Revert");
+    revertButton->setFixedWidth(subdivControlsWidth/2-10);
     revertButton->setDisabled(true);
 
     QObject::connect(subdivisionButton,SIGNAL(clicked(bool)),this,SLOT(doSubdivision()));
@@ -49,8 +51,8 @@ MainWindow::MainWindow(QWidget *parent) :
     vBoxSubdivControls->addStretch(1);
 
     openglWidget = new MainOpenGLWidget(this);
-    openglWidget->setFixedWidth(this->width()-subdivControlsWidth);
-    openglWidget->setFixedHeight(this->height());
+    //openglWidget->setFixedWidth(this->width()-subdivControlsWidth);
+    //openglWidget->setFixedHeight(this->height());
 
     mainLayout->addLayout(vBoxSubdivControls);
     mainLayout->addWidget(openglWidget);

--- a/MeshWalkHandler.cpp
+++ b/MeshWalkHandler.cpp
@@ -158,8 +158,9 @@ int MeshWalkHandler::quadOddVerticesTwoNeighbour(std::array<K::Point_3, 16>& ver
 }
 
 inline int MeshWalkHandler::quadFaceOddTwo(std::array<K::Point_3, 16>& vertices, Polyhedron::Halfedge_iterator halfedge) {
-    Polyhedron::Halfedge_iterator c = halfedge;
+    Polyhedron::Halfedge_iterator edge = halfedge;
 
+    /*
     c = c->next()->opposite()->next();
 
     c = quadFaceOddTwoSideHelper(c, vertices, std::pair<int, int>(7, 6));
@@ -170,6 +171,51 @@ inline int MeshWalkHandler::quadFaceOddTwo(std::array<K::Point_3, 16>& vertices,
     c = quadFaceOddTwoCornerHelper(c, vertices, std::pair<int, int>(12, 13));
     c = quadFaceOddTwoSideHelper(c, vertices, std::pair<int, int>(14, 10));
     c = quadFaceOddTwoCornerHelper(c, vertices, std::pair<int, int>(15, 11));
+    */
+
+    Polyhedron::Point& p1 = edge->vertex()->point();
+    Polyhedron::Point& p2 = edge->next()->vertex()->point();
+    Polyhedron::Point& p3 = edge->next()->next()->vertex()->point();
+    Polyhedron::Point& p4 = edge->next()->next()->next()->vertex()->point();
+
+    Polyhedron::Point& p5 = edge->opposite()->next()->next()->next()->opposite()->next()->vertex()->point();
+    Polyhedron::Point& p6 = edge->next()->opposite()->next()->vertex()->point();
+    Polyhedron::Point& p7 = edge->next()->opposite()->next()->next()->vertex()->point();
+    Polyhedron::Point& p8 = edge->next()->next()->opposite()->next()->opposite()->next()->next()->vertex()->point();
+
+    Polyhedron::Point& p9 = edge->next()->next()->opposite()->next()->vertex()->point();
+    Polyhedron::Point& p10 = edge->next()->next()->opposite()->next()->next()->vertex()->point();
+    Polyhedron::Point& p11 = edge->next()->next()->next()->opposite()->next()->opposite()->next()->next()->vertex()->point();
+    Polyhedron::Point& p12 = edge->next()->next()->next()->opposite()->next()->vertex()->point();
+
+    Polyhedron::Point& p13 = edge->opposite()->next()->opposite()->next()->vertex()->point();
+    Polyhedron::Point& p14 = edge->opposite()->next()->opposite()->next()->next()->vertex()->point();
+    Polyhedron::Point& p15 = edge->opposite()->next()->vertex()->point();
+    Polyhedron::Point& p16 = edge->opposite()->next()->next()->vertex()->point();
+
+    // f: 1 2 3 4
+    // s: 5, 8, 11, 14
+    // t: 6 7 9 10 12 13 15 16
+
+    vertices[0] = p5;
+    vertices[1] = p6;
+    vertices[2] = p7;
+    vertices[3] = p8;
+
+    vertices[4] = p9;
+    vertices[5] = p1;
+    vertices[6] = p2;
+    vertices[7] = p10;
+
+    vertices[8] = p15;
+    vertices[9] = p3;
+    vertices[10] = p4;
+    vertices[11] = p16;
+
+    vertices[12] = p11;
+    vertices[13] = p12;
+    vertices[14] = p13;
+    vertices[15] = p14;
 
     return 16;
 }
@@ -193,15 +239,14 @@ inline Polyhedron::Halfedge_iterator MeshWalkHandler::quadFaceOddTwoSideHelper(P
 inline int MeshWalkHandler::quadEdgeOddTwo(std::array<K::Point_3, 16>& vertices, Polyhedron::Halfedge_iterator halfedge) {
     Polyhedron::Halfedge_iterator c = halfedge;
 
-    vertices[1] = c->prev()->vertex()->point();
+    vertices[1] = c->opposite()->vertex()->point();
     vertices[2] = c->vertex()->point();
 
-    c = quadEdgeOddTwoStraightHelper(c);
+    Polyhedron::Halfedge_iterator cTmp = quadEdgeOddTwoStraightHelper(c);
 
-    vertices[3] = c->vertex()->point();
+    vertices[3] = cTmp->vertex()->point();
 
     c = c->opposite();
-    c = quadEdgeOddTwoStraightHelper(c);
     c = quadEdgeOddTwoStraightHelper(c);
 
     vertices[0] = c->vertex()->point();

--- a/WeightArrayGenerator.cpp
+++ b/WeightArrayGenerator.cpp
@@ -98,22 +98,20 @@ std::array<float, 16> WeightArrayGenerator::generateQuadWeights(CustomScheme cus
 }
 
 std::array<float, 16> WeightArrayGenerator::generateQuadOneWeights(CustomScheme custom_scheme, MeshWalkHandler::OddsType odds_type) {
+    float f, s;
+
     switch (odds_type) {
     case MeshWalkHandler::OddsType::Face:
         // Like CatmullClark face odd
-        for (OddWeight w : custom_scheme.weights.odd) {
-            if (w.level == 0 && w.type == CustomSchemeOddWeightType::Face) {
-                float f =  1 / 4;
-                return std::array<float, 16>{{f, f, f, f}};
-            }
-        }
+        f =  1.0 / 4.0;
+        return std::array<float, 16>{{f, f, f, f}};
         break;
     case MeshWalkHandler::OddsType::Edge:
         // Like CatmullClark edge odd
         for (OddWeight w : custom_scheme.weights.odd) {
             if (w.level == 0 && w.type == CustomSchemeOddWeightType::Edge) {
-                float f = w.value;
-                float s = (1.0 - 2.0 * f) / 4.0;
+                f = w.value;
+                s = (1.0 - 2.0 * f) / 4.0;
                 return std::array<float, 16>{{s, s, f, f, s, s}};
             }
         }


### PR DESCRIPTION
- Disable triangulation on OBJ file read
- Rewrite/copy quad 2 neighbour walking to CustomSchemeSubdivisionStrategy
- Fix custom scheme creation in custom window
- Fix weight array generation for quad odd face 1 neighbour
- Add more debug related methods